### PR TITLE
Fix creation of WorkDir and format of output from run_xstar

### DIFF
--- a/multixstar_logging.py
+++ b/multixstar_logging.py
@@ -220,7 +220,7 @@ def check_results(padded):
 
 def main(argv=None):
     # arg processing
-    max_process, workDir, args, log_file, keeplog = new_process_flags()
+    max_process, workDir, args, log_file, keeplog = process_flags()
 
     check_enviroment(workDir)
 

--- a/multixstar_logging.py
+++ b/multixstar_logging.py
@@ -199,8 +199,6 @@ def main(argv=None):
     check_enviroment(workDir)
 
     wdir = "mxstar." + str(get_sufix(workDir))
-    if not workDir[-1] == "/":
-        workDir += "/"
     workDir += wdir
     os.mkdir(workDir)
     os.chdir(workDir)

--- a/multixstar_logging.py
+++ b/multixstar_logging.py
@@ -152,14 +152,18 @@ def get_xcmds(args=[], binpath=""):
             if not args[0][0] == "/":
                 to_return = "2" + "\n"
                 joblist = args[0]
-                os.rename("../" + joblist, os.getcwd() + "/" + joblist.split("/")[-1])
+                os.rename("../" + joblist,
+                          os.path.join(os.getcwd(), joblist.split("/")[-1]))
                 if joblist[-4:] == ".fits":
                     old1 = ".fits"
                     new1 = ".lis"
                 else:
                     old1 = ".lis"
                     new1 = ".fits"
-                os.rename("../" + joblist.replace(old1, new1), os.getcwd() + "/" + joblist.split("/")[-1].replace(old1, new1))
+                os.rename("../" + joblist.replace(old1, new1),
+                          os.path.join(os.getcwd(),
+                                       joblist.split("/")[-1].replace(old1,
+                                                                      new1)))
             else:
                 os.rename(joblist, workDir + joblist.split("/")[-1])
                 joblist = joblist.split("/")[-1]
@@ -242,8 +246,8 @@ def main(argv=None):
         padded = list(xcmd_dict.keys())
         padded.sort()
         for pad in padded:
-            run("$FTOOLS/bin/xstar2table xstarspec=" + workDir + "/" +
-                model_name + "/" + pad + "/xout_spect1.fits", os.environ)
+            run("$FTOOLS/bin/xstar2table xstarspec=" +
+                os.path.join(workDir, model_name, pad, "xout_spect1.fits"), os.environ)
         if not keeplog:
             run("rm " + log_file)
     else:

--- a/multixstar_logging.py
+++ b/multixstar_logging.py
@@ -10,7 +10,6 @@ using the multiprocessing python module.  XSTAR is part of the LHEASOFT astronom
 HEASARC, and is used to for calculating the physical conditions and
 emission spectra of photoionized gases (Kallman & Bautista 2001).
 """
-
 from __future__ import print_function
 from __future__ import division
 from __future__ import unicode_literals
@@ -24,31 +23,37 @@ import datetime
 import logging
 
 
+__version__ = "0.1.1"
+
+
 def print_help():
-     print("""
-     multixstar: manages parallel execution of multiple XSTAR jobs, with python's multiprocessing module
-     Version 0.1
+    flags = ["-w      the working dir (default will be `./`) WorkDir must exist & be writable",
+             # "  -i <file>         a script to run before running xstar",
+             "\t  -k                keep log: do not delete after successful run",
+             "\t  -l <log>          redirect console output to log file",
+             "\t  -n <N>           set max number processes per host to N (default: 4)",
+             # "  -j  <file|param>  a joblist or a xstinitable parameters",
+             "\t  -h,--help         prints this message",
+             "\t  -s,--no-help     surpresses help message so you can run with defaults"]
 
-     Usage:  multixstar [options] <joblist|params>
+    print("""
+          multixstar: manages parallel execution of multiple XSTAR jobs, with python's multiprocessing module
+          Version {version}
 
+          Usage:  multixstar [options] <joblist|params>
 
-     Supported options are:"
-       -w                the working dir (default will be `./`) WorkDir must exist & be writable
-       -k                keep log: do not delete after successful run
-       -l <log>          redirect console output to log file
-       -n <N>           set max number processes per host to N (default: 4)
-       -h,--help         prints this message
-       -s,--no-help     surpresses help message so you can run with defaults
+          Supported options are:
 
-     Normally xstinitable will be launched to prompt for XSTAR physical
-     parameters and generate a list of XSTAR jobs to run in parallel.
-     This can be customized by supplying xstinitable parameters on the
-     command line (such as mode=h) OR by supplying the name of an
-     existing joblist file, in which case xstinitable will not be run
-     nor will the generated spectra be collated into a single table
-     model with xstar2table.
-     """)
+          {flags}
 
+          Normally xstinitable will be launched to prompt for XSTAR physical
+          parameters and generate a list of XSTAR jobs to run in parallel.
+          This can be customized by supplying xstinitable parameters on the
+          command line (such as mode=h) OR by supplying the name of an
+          existing joblist file, in which case xstinitable will not be run
+          nor will the generated spectra be collated into a single table
+          model with xstar2table.\n""".format(version=__version__,
+                                              flags="\n".join(flags)))
 
 
 def run(cmd, env_setup="", stdout=True):

--- a/multixstar_logging.py
+++ b/multixstar_logging.py
@@ -129,7 +129,7 @@ def process_flags(argv=None):
     else:
         ans = "blank"
         while not ans.lower()[0] == "y" and not ans.lower()[0] == "n":
-            ans = raw_input("Would you like to continue with defaults?\n").strip() + "blank"
+            ans = enter_input("Would you like to continue with defaults?\n").strip() + "blank"
         if ans.lower()[0] == "n":
             print_help()
             os.sys.exit()
@@ -267,4 +267,10 @@ def main(argv=None):
         rootLogger.info("somethings not right in " + ",".join(str(failed)))
 
 if __name__ == '__main__':
+    # Use `raw_input` if python2 and `input` if python3
+    if os.sys.version_info[:2] <= (3, 0):
+        enter_input = raw_input
+    else:
+        enter_input = input
+
     main()

--- a/multixstar_logging.py
+++ b/multixstar_logging.py
@@ -67,7 +67,7 @@ def run(cmd, env_setup="", stdout=True):
 def run_xstar(xcmd):
     to_return = ""
     os.chdir(xcmd[0])
-    to_return + = "Running:" + xcmd[0] + "\n"
+    to_return += "Running:" + xcmd[0] + "\n"
     os.environ['PFILES'] = os.getcwd()
     to_return = "copycat" + "\n"
     subprocess.Popen("cp $HEADAS/syspfiles/xstar.par ./", shell=True, executable=os.getenv("SHELL"), stdout=subprocess.PIPE, env=os.environ).wait()
@@ -216,7 +216,7 @@ def main(argv=None):
     os.mkdir(wdir)
     os.chdir(wdir)
     if not workDir[-1] == "/":
-        workDir + ="/"
+        workDir +="/"
     workDir += wdir
 
     xcmds = get_xcmds(args, os.environ["FTOOLS"] + "/bin/")

--- a/multixstar_logging.py
+++ b/multixstar_logging.py
@@ -24,31 +24,30 @@ import logging
 
 
 def print_help():
-    print ""
-    print "multixstar: manages parallel execution of multiple XSTAR jobs, with python's multiprocessing module"
-    print "Version 0.1"
-    print
-    print "Usage:  multixstar [options] <joblist|params>"
-    print
-    print
-    print "Supported options are:"
-    print "  -w                the working dir (default will be `./`) WorkDir must exist & be writable"
-    # print "  -i <file>         a script to run before running xstar"
-    print "  -k                keep log: do not delete after successful run"
-    print "  -l <log>          redirect console output to log file"
-    print "  -n <N>           set max number processes per host to N (default: 4)"
-    # print "  -j  <file|param>  a joblist or a xstinitable parameters"
-    print "  -h,--help         prints this message"
-    print "  -s,--no-help     surpresses help message so you can run with defaults"
-    print
-    print "Normally xstinitable will be launched to prompt for XSTAR physical"
-    print "parameters and generate a list of XSTAR jobs to run in parallel."
-    print "This can be customized by supplying xstinitable parameters on the"
-    print "command line (such as mode=h) OR by supplying the name of an "
-    print "existing joblist file, in which case xstinitable will not be run"
-    print "nor will the generated spectra be collated into a single table"
-    print "model with xstar2table."
-    print
+     print("""
+     multixstar: manages parallel execution of multiple XSTAR jobs, with python's multiprocessing module
+     Version 0.1
+
+     Usage:  multixstar [options] <joblist|params>
+
+
+     Supported options are:"
+       -w                the working dir (default will be `./`) WorkDir must exist & be writable
+       -k                keep log: do not delete after successful run
+       -l <log>          redirect console output to log file
+       -n <N>           set max number processes per host to N (default: 4)
+       -h,--help         prints this message
+       -s,--no-help     surpresses help message so you can run with defaults
+
+     Normally xstinitable will be launched to prompt for XSTAR physical
+     parameters and generate a list of XSTAR jobs to run in parallel.
+     This can be customized by supplying xstinitable parameters on the
+     command line (such as mode=h) OR by supplying the name of an
+     existing joblist file, in which case xstinitable will not be run
+     nor will the generated spectra be collated into a single table
+     model with xstar2table.
+     """)
+
 
 
 def run(cmd, env_setup="", stdout=True):

--- a/multixstar_logging.py
+++ b/multixstar_logging.py
@@ -165,7 +165,8 @@ def get_xcmds(args=[], binpath=""):
                                        joblist.split("/")[-1].replace(old1,
                                                                       new1)))
             else:
-                os.rename(joblist, workDir + joblist.split("/")[-1])
+                os.rename(joblist,
+                          os.path.join(workDir, joblist.split("/")[-1]))
                 joblist = joblist.split("/")[-1]
     else:
         run(binpath + "xstinitable", os.environ)
@@ -199,8 +200,6 @@ def main(argv=None):
     check_enviroment(workDir)
 
     wdir = "mxstar." + str(get_sufix(workDir))
-    if not workDir[-1] == "/":
-        workDir += "/"
     workDir += wdir
     os.mkdir(workDir)
     os.chdir(workDir)

--- a/multixstar_logging.py
+++ b/multixstar_logging.py
@@ -242,7 +242,8 @@ def main(argv=None):
         padded = list(xcmd_dict.keys())
         padded.sort()
         for pad in padded:
-            run("$FTOOLS/bin/xstar2table xstarspec=./" + pad + "/xout_spect1.fits", os.environ)
+            run("$FTOOLS/bin/xstar2table xstarspec=" + workDir + "/" +
+                model_name + "/" + pad + "/xout_spect1.fits", os.environ)
         if not keeplog:
             run("rm " + log_file)
     else:

--- a/multixstar_logging.py
+++ b/multixstar_logging.py
@@ -221,7 +221,7 @@ def main(argv=None):
 
     xcmds = get_xcmds(args, os.environ["FTOOLS"] + "/bin/")
     xcmd_dict = make_xcmd_dict(xcmds)
-    model_name = dict([z.split("=")for z in xcmd_dict[xcmd_dict.keys()[0]].replace("xstar ", "").split()])["modelname"].replace("'", "").replace('"', '')
+    model_name = dict([z.split("=")for z in xcmd_dict[list(xcmd_dict.keys())[0]].replace("xstar ", "").split()])["modelname"].replace("'", "").replace('"', '')
     if not os.path.exists(model_name):
         os.mkdir(model_name)
     os.chdir(model_name)
@@ -257,7 +257,7 @@ def main(argv=None):
     if len(failed) == 0:
         for dest in ['xout_ain.fits', 'xout_aout.fits', 'xout_mtable.fits']:
             run("cp ../xstinitable.fits " + dest)
-        padded = xcmd_dict.keys()
+        padded = list(xcmd_dict.keys())
         padded.sort()
         for pad in padded:
             run("$FTOOLS/bin/xstar2table xstarspec=./" + pad + "/xout_spect1.fits", os.environ)

--- a/multixstar_logging.py
+++ b/multixstar_logging.py
@@ -46,14 +46,14 @@ def run_xstar(xcmd):
     os.chdir(xcmd[0])
     to_return += "Running:" + xcmd[0] + "\n"
     os.environ['PFILES'] = os.getcwd()
-    to_return = "copycat" + "\n"
+    to_return += "copycat" + "\n"
     subprocess.Popen("cp $HEADAS/syspfiles/xstar.par ./", shell=True, executable=os.getenv("SHELL"), stdout=subprocess.PIPE, env=os.environ).wait()
-    to_return = xcmd[1] + "\n"
+    to_return += xcmd[1] + "\n"
     p = subprocess.Popen("$FTOOLS/bin/" + xcmd[1], shell=True, executable=os.getenv("SHELL"), stdout=subprocess.PIPE, env=os.environ)
-    to_return = str(p.pid) + "\n"
+    to_return += str(p.pid) + "\n"
     output = p.stdout.readlines()
     os.chdir("../")
-    to_return = "\n".join(str(output)) + "\n"
+    to_return += "\n".join([line.decode("utf-8") for line in output]) + "\n"
     return to_return
 
 

--- a/multixstar_logging.py
+++ b/multixstar_logging.py
@@ -195,11 +195,11 @@ def main(argv=None):
     check_enviroment(workDir)
 
     wdir = "mxstar." + str(get_sufix(workDir))
-    os.mkdir(wdir)
-    os.chdir(wdir)
     if not workDir[-1] == "/":
         workDir += "/"
     workDir += wdir
+    os.mkdir(workDir)
+    os.chdir(workDir)
 
     xcmds = get_xcmds(args, os.environ["FTOOLS"] + "/bin/")
     xcmd_dict = make_xcmd_dict(xcmds)

--- a/multixstar_logging.py
+++ b/multixstar_logging.py
@@ -27,36 +27,6 @@ import logging
 __version__ = "0.1.1"
 
 
-def print_help():
-    flags = ["-w      the working dir (default will be `./`) WorkDir must exist & be writable",
-             # "  -i <file>         a script to run before running xstar",
-             "\t  -k                keep log: do not delete after successful run",
-             "\t  -l <log>          redirect console output to log file",
-             "\t  -n <N>           set max number processes per host to N (default: 4)",
-             # "  -j  <file|param>  a joblist or a xstinitable parameters",
-             "\t  -h,--help         prints this message",
-             "\t  -s,--no-help     surpresses help message so you can run with defaults"]
-
-    print("""
-          multixstar: manages parallel execution of multiple XSTAR jobs, with python's multiprocessing module
-          Version {version}
-
-          Usage:  multixstar [options] <joblist|params>
-
-          Supported options are:
-
-          {flags}
-
-          Normally xstinitable will be launched to prompt for XSTAR physical
-          parameters and generate a list of XSTAR jobs to run in parallel.
-          This can be customized by supplying xstinitable parameters on the
-          command line (such as mode=h) OR by supplying the name of an
-          existing joblist file, in which case xstinitable will not be run
-          nor will the generated spectra be collated into a single table
-          model with xstar2table.\n""".format(version=__version__,
-                                              flags="\n".join(flags)))
-
-
 def run(cmd, env_setup="", stdout=True):
     '''runs cmds in systems shell.'''
     def return_stdout(p):

--- a/multixstar_logging.py
+++ b/multixstar_logging.py
@@ -11,6 +11,10 @@ HEASARC, and is used to for calculating the physical conditions and
 emission spectra of photoionized gases (Kallman & Bautista 2001).
 """
 
+from __future__ import print_function
+from __future__ import division
+from __future__ import unicode_literals
+from __future__ import absolute_import
 import subprocess
 import os
 import multiprocessing as mp

--- a/multixstar_logging.py
+++ b/multixstar_logging.py
@@ -76,7 +76,7 @@ def run_xstar(xcmd):
     to_return = str(p.pid) + "\n"
     output = p.stdout.readlines()
     os.chdir("../")
-    to_return = "\n".join(output) + "\n"
+    to_return = "\n".join(str(output)) + "\n"
     return to_return
 
 
@@ -164,7 +164,7 @@ def get_xcmds(args=[], binpath=""):
     if len(args) > 0:
         if not os.path.exists("../" + args[0]):
             to_return = 1 + "\n"
-            run(binpath + "xstinitable " + " ".join(args), os.environ)
+            run(binpath + "xstinitable " + " ".join(str(args)), os.environ)
             joblist = "xstinitable.lis"
         else:
             if not args[0][0] == "/":
@@ -264,7 +264,7 @@ def main(argv=None):
         if not keeplog:
             run("rm " + log_file)
     else:
-        rootLogger.info("somethings not right in " + ",".join(failed))
+        rootLogger.info("somethings not right in " + ",".join(str(failed)))
 
 if __name__ == '__main__':
     main()

--- a/multixstar_logging.py
+++ b/multixstar_logging.py
@@ -15,6 +15,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import unicode_literals
 from __future__ import absolute_import
+from six.moves import input
 import subprocess
 import os
 import multiprocessing as mp
@@ -129,7 +130,7 @@ def process_flags(argv=None):
     else:
         ans = "blank"
         while not ans.lower()[0] == "y" and not ans.lower()[0] == "n":
-            ans = enter_input("Would you like to continue with defaults?\n").strip() + "blank"
+            ans = input("Would you like to continue with defaults?\n").strip() + "blank"
         if ans.lower()[0] == "n":
             print_help()
             os.sys.exit()
@@ -267,10 +268,4 @@ def main(argv=None):
         rootLogger.info("somethings not right in " + ",".join(str(failed)))
 
 if __name__ == '__main__':
-    # Use `raw_input` if python2 and `input` if python3
-    if os.sys.version_info[:2] <= (3, 0):
-        enter_input = raw_input
-    else:
-        enter_input = input
-
     main()

--- a/multixstar_logging.py
+++ b/multixstar_logging.py
@@ -118,7 +118,7 @@ def process_flags(argv=None):
         parser.print_help()
         os.sys.exit()
     else:
-        workDir = options.workdir
+        workDir = os.path.abspath(options.workdir)
         keeplog = options.keeplog
         log_file = options.logfile
         max_process = options.nproc


### PR DESCRIPTION
The previous code checks if the `workdir` exists but then don't use it, instead it creates `mxstar.#` and `mxstar.#/<modelname>` and leaves `workDir` alone
Also, the output of `run_xstar` was a long sequence of single character from a bite string

This PR:
   + Fixes for Workdir
     - checks if `workDir` exists, is a dir and writable
     - creates `mxstar.#` inside `workDir`
     - creates subproducts and `<modelname>` dir inside `mxstar.X`
   + Fixes for output of run_xstar
     - concatenates the different outputs as it looks like that was the original idea
     - decodes the bite string that is outputed by readlines() into unicode string (standard in Python3)

Needs #1 and #3 to clean commit history